### PR TITLE
Provide a default code grant

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -301,6 +301,34 @@ app.saveAuthorizationCode = function(fn) {
 };
 
 /**
+ * Register a callback to generate an authorization code
+ *
+ * @param {Function} fn
+ * @optional
+ * @api public
+ */
+
+app.generateAuthorizationCode = function(fn) {
+  debug('registering callback generateAuthorizationCode');
+  this.callbacks.generateAuthorizationCode = fn;
+  return this;
+};
+
+/**
+ * Register a callback to generate and save an authorization code
+ *
+ * @param {Function} fn
+ * @optional
+ * @api public
+ */
+
+app.createAuthorizationCode = function(fn) {
+  debug('registering callback createAuthorizationCode');
+  this.callbacks.createAuthorizationCode = fn;
+  return this;
+};
+
+/**
  * Register a callback to invalidate an authorization code
  *
  * @param {Function} fn

--- a/lib/auth/grants/code.js
+++ b/lib/auth/grants/code.js
@@ -3,10 +3,38 @@
  */
 
 var debug = require('debug')('consulate:auth:grants:code')
-  , oauth2orize = require('oauth2orize');
+  , oauth2orize = require('oauth2orize')
+  , uid = require('websafe-uid').uid;
 
 module.exports = function(callbacks) {
-  var createAuthorizationCode = callbacks('createAuthorizationCode');
+  var createAuthorizationCode = callbacks('createAuthorizationCode', defaultCreate)
+    , generateAuthorizationCode = callbacks('generateAuthorizationCode', generateAuthorizationCodeUID)
+    , saveAuthorizationCode = callbacks('saveAuthorizationCode');
 
-  return oauth2orize.grant.code(createAuthorizationCode);
+  // Default workflow
+  function defaultCreate(client, redirectURI, user, ares, done) {
+    debug('creating auth code for client', client);
+    generateAuthorizationCode(function(err, code) {
+      debug('created auth code '+code);
+      if (err) return done(err);
+
+      // Get auth code info from the code
+      // TODO we should save the requested scope as well
+      debug('saving auth code '+code);
+      saveAuthorizationCode(code, user.id, client.id, redirectURI, function(err) {
+        debug('saved auth code '+code, err);
+        if (err) return done(err);
+        done(null, code);
+      });
+    });
+  };
+
+  // List the arguments so oauth2orize can inspect the length
+  return oauth2orize.grant.code(function(client, redirectURI, user, ares, done) {
+    createAuthorizationCode.apply(null, arguments);
+  });
+}
+
+function generateAuthorizationCodeUID (done) {
+  done(null, uid(128));
 }


### PR DESCRIPTION
This provides the best of both worlds where most users can get a default workflow (`generate -> save`) and if a user wants a more customizable workflow it can set the `createAuthorizationCode`
