### PR TITLE
Allow the app to skip user authorization screen

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -92,7 +92,7 @@ app.defaultConfiguration = function(opts) {
     .post(loginPath, self.authenticate(user), self.viewCallback('login'));
 
   self
-    .get(authorizePath, login.ensureLoggedIn(), oauth2.authorizeClient(), oauth2.authorizeLocals(), self.viewCallback('authorize'))
+    .get(authorizePath, login.ensureLoggedIn(), oauth2.authorizeClient(), oauth2.authorizeLocals(), self.viewCallback('authorize'), oauth2.decision())
     .post(decisionPath, login.ensureLoggedIn(), oauth2.decision());
 };
 


### PR DESCRIPTION
Useful for clients which are part of the same platform as
the consulate app, or when the authorization of the client
by the user is remembered by the consulate app.
