### PR TITLE
get/save user decision callback

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+* allow a client to auto authorize (internal apps)
+* write callback documentation
+* update the examples
+* make a createAuthCode lib with simple-secrets
+* support setting which callback get applied to grants/exchanges

--- a/lib/application.js
+++ b/lib/application.js
@@ -91,9 +91,13 @@ app.defaultConfiguration = function(opts) {
     .get(loginPath, self.viewCallback('login'))
     .post(loginPath, self.authenticate(user), self.viewCallback('login'));
 
+  var decision = oauth2.decision()
+    , transactionLoader = decision[0];
+
   self
-    .get(authorizePath, login.ensureLoggedIn(), oauth2.authorizeClient(), oauth2.authorizeLocals(), self.viewCallback('authorize'), oauth2.decision())
-    .post(decisionPath, login.ensureLoggedIn(), oauth2.decision());
+    .get(authorizePath, login.ensureLoggedIn(), oauth2.authorizeClient(), oauth2.authorizeLocals(), oauth2.getPreviousDecision(), decision)
+    .get(authorizePath, self.viewCallback('authorize'))
+    .post(decisionPath, login.ensureLoggedIn(), transactionLoader, oauth2.rememberDecision(), decision);
 };
 
 /**
@@ -307,6 +311,32 @@ app.client = function(fn) {
 app.isValidClientRedirectURI = function(fn) {
   debug('registering callback isValidClientRedirectURI');
   this.callbacks.isValidClientRedirectURI = fn;
+  return this;
+};
+
+/**
+ * Register a callback to get a user's previous authorization decision
+ *
+ * @param {Function} fn
+ * @api public
+ */
+
+app.userDecision = function(fn) {
+  debug('registering callback userDecision');
+  this.callbacks.userDecision = fn;
+  return this;
+};
+
+/**
+ * Register a callback to save a user's authorization decision
+ *
+ * @param {Function} fn
+ * @api public
+ */
+
+app.saveUserDecision = function(fn) {
+  debug('registering callback saveUserDecision');
+  this.callbacks.saveUserDecision = fn;
   return this;
 };
 

--- a/lib/auth/server.js
+++ b/lib/auth/server.js
@@ -8,7 +8,9 @@ var debug = require('simple-debug')('consulate:auth:server')
 exports = module.exports = function(callbacks) {
   var server = oauth2orize()
     , getClient = callbacks('client')
-    , isValidClientRedirectURI = callbacks('isValidClientRedirectURI');
+    , isValidClientRedirectURI = callbacks('isValidClientRedirectURI')
+    , getUserDecision = callbacks('userDecision', function(user, client, done) { done(); })
+    , saveUserDecision = callbacks('saveUserDecision', function(user, client, decision, done) { done(); });
 
   // Serialize the client
   server.serializeClient(function(client, done) {
@@ -43,6 +45,34 @@ exports = module.exports = function(callbacks) {
 
       });
     });
+  };
+
+  // Retrieve a previous decision
+  server.getPreviousDecision = function() {
+    return function(req, res, next) {
+      getUserDecision(req.user, req.oauth2.client, function(err, decision) {
+        if (err) return next(err);
+        // If the decision was no, render the view
+        if (!decision) return next('route');
+
+        // TODO decision should probably be a list of approved scopes
+
+        // Pass it on to the decision handler
+        next();
+      });
+    };
+  };
+
+  // Remeber a user decision
+  server.rememberDecision = function() {
+    return function(req, res, next) {
+      var decision = !req.body.cancel;
+
+      saveUserDecision(req.user, req.oauth2.client, decision, function(err) {
+        if (err) return next(err);
+        next(err);
+      });
+    };
   };
 
   // Setup the authorize endpoint locals

--- a/lib/auth/server.js
+++ b/lib/auth/server.js
@@ -50,7 +50,7 @@ exports = module.exports = function(callbacks) {
   // Retrieve a previous decision
   server.getPreviousDecision = function() {
     return function(req, res, next) {
-      getUserDecision(req.user, req.oauth2.client, function(err, decision) {
+      getUserDecision(req, req.user, req.oauth2.client, function(err, decision) {
         if (err) return next(err);
         // If the decision was no, render the view
         if (!decision) return next('route');
@@ -68,7 +68,7 @@ exports = module.exports = function(callbacks) {
     return function(req, res, next) {
       var decision = !req.body.cancel;
 
-      saveUserDecision(req.user, req.oauth2.client, decision, function(err) {
+      saveUserDecision(req, req.user, req.oauth2.client, decision, function(err) {
         if (err) return next(err);
         next(err);
       });

--- a/lib/auth/user.js
+++ b/lib/auth/user.js
@@ -19,14 +19,14 @@ module.exports = function(callbacks) {
     , userByUsername = callbacks('userByUsername')
     , verifyPassword = callbacks('verifyPassword');
 
-  passport.serializeUser(function(user, done) {
+  passport.serializeUser(function(req, user, done) {
     debug('serializing user', user);
     done(null, user.id);
   });
 
-  passport.deserializeUser(function(id, done) {
+  passport.deserializeUser(function(req, id, done) {
     debug('deserializing user_id', id);
-    getUser(id, function(err, user) {
+    getUser(req, id, function(err, user) {
       debug('deserialized user_id', id, user);
       if (err) return done(err);
       return done(null, user);


### PR DESCRIPTION
The idea would be to relieve the `authorize` view callback from making api calls and just focusing on rendering a view and having a couple of extra callbacks that would allow consumers to get/save the authorization decisions of the users. In my mind it makes sense. Let me know what you think, @timshadel.
