### PR TITLE
improve callback naming

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -202,7 +202,7 @@ app.viewCallback = function(name, defaultCb) {
  * for a set of scopes is valid. The callback should pass back a list of those
  * valid scopes.
  *
- *     app.scopes(function(done) {
+ *     app.getScopes(function(done) {
  *       // Possibly make a call to the db or pull from `process.env`
  *       var scopes = process.env.SCOPES.split(',');
  *       done(null, scopes);
@@ -212,11 +212,12 @@ app.viewCallback = function(name, defaultCb) {
  * @api public
  */
 
-app.scopes = function(fn) {
-  debug('registering callback scopes');
-  this.addCallback('scopes', fn);
+app.getScopes = function(fn) {
+  debug('registering callback getScopes');
+  this.addCallback('getScopes', fn);
   return this;
 };
+backward(app, 'scopes', 'getScopes');
 
 /**
  * Register a callback to issue a token for a given user/client
@@ -267,11 +268,12 @@ app.issueToken = function(fn) {
  * @api public
  */
 
-app.user = function(fn) {
-  debug('registering callback user');
-  this.addCallback('user', fn);
+app.getUser = function(fn) {
+  debug('registering callback getUser');
+  this.addCallback('getUser', fn);
   return this;
 };
+backward(app, 'user', 'getUser');
 
 /**
  * Register a callback to find a user by username
@@ -280,11 +282,12 @@ app.user = function(fn) {
  * @api public
  */
 
-app.userByUsername = function(fn) {
-  debug('registering callback userByUsername');
-  this.addCallback('userByUsername', fn);
+app.getUserByUsername = function(fn) {
+  debug('registering callback getUserByUsername');
+  this.addCallback('getUserByUsername', fn);
   return this;
 };
+backward(app, 'userByUsername', 'getUserByUsername');
 
 /**
  * Register a callback to list a user's allowed scopes
@@ -293,11 +296,12 @@ app.userByUsername = function(fn) {
  * @api public
  */
 
-app.allowedUserScopes = function(fn) {
-  debug('registering callback allowedUserScopes');
-  this.addCallback('allowedUserScopes', fn);
+app.getAllowedUserScopes = function(fn) {
+  debug('registering callback getAllowedUserScopes');
+  this.addCallback('getAllowedUserScopes', fn);
   return this;
 };
+backward(app, 'allowedUserScopes', 'getAllowedUserScopes');
 
 /**
  * Register a callback to verify a user provided password
@@ -319,11 +323,12 @@ app.verifyPassword = function(fn) {
  * @api public
  */
 
-app.client = function(fn) {
-  debug('registering callback client');
-  this.addCallback('client', fn);
+app.getClient = function(fn) {
+  debug('registering callback getClient');
+  this.addCallback('getClient', fn);
   return this;
 };
+backward(app, 'client', 'getClient');
 
 /**
  * Register a callback to verify that a client may use the provided uri as the redirect_uri
@@ -332,11 +337,12 @@ app.client = function(fn) {
  * @api public
  */
 
-app.isValidClientRedirectURI = function(fn) {
-  debug('registering callback isValidClientRedirectURI');
-  this.addCallback('isValidClientRedirectURI', fn);
+app.verifyClientRedirectURI = function(fn) {
+  debug('registering callback verifyClientRedirectURI');
+  this.addCallback('verifyClientRedirectURI', fn);
   return this;
 };
+backward(app, 'isValidClientRedirectURI', 'verifyClientRedirectURI');
 
 /**
  * Register a callback to get a user's previous authorization decision
@@ -345,11 +351,12 @@ app.isValidClientRedirectURI = function(fn) {
  * @api public
  */
 
-app.userDecision = function(fn) {
-  debug('registering callback userDecision');
-  this.addCallback('userDecision', fn);
+app.getUserDecision = function(fn) {
+  debug('registering callback getUserDecision');
+  this.addCallback('getUserDecision', fn);
   return this;
 };
+backward(app, 'userDecision', 'getUserDecision');
 
 /**
  * Register a callback to save a user's authorization decision
@@ -372,11 +379,12 @@ app.saveUserDecision = function(fn) {
  * @api public
  */
 
-app.authorizationCode = function(fn) {
-  debug('registering callback authorizationCode');
-  this.addCallback('authorizationCode', fn);
+app.getAuthorizationCode = function(fn) {
+  debug('registering callback getAuthorizationCode');
+  this.addCallback('getAuthorizationCode', fn);
   return this;
 };
+backward(app, 'authorizationCode', 'getAuthorizationCode');
 
 /**
  * Register a callback to create and save an authorization code
@@ -412,11 +420,12 @@ app.invalidateAuthorizationCode = function(fn) {
  * @api public
  */
 
-app.refreshToken = function(fn) {
-  debug('registering callback refreshToken');
-  this.addCallback('refreshToken', fn);
+app.getRefreshToken = function(fn) {
+  debug('registering callback getRefreshToken');
+  this.addCallback('getRefreshToken', fn);
   return this;
 };
+backward(app, 'refreshToken', 'getRefreshToken');
 
 /**
  * Register a callback to issue a refresh token for a given user/client
@@ -443,6 +452,20 @@ app.invalidateRefreshToken = function(fn) {
   this.addCallback('invalidateRefreshToken', fn);
   return this;
 };
+
+/**
+ * Get any additional parameters to the response
+ *
+ * @param {Function} fn
+ * @api public
+ */
+
+app.getAdditionalParams = function(fn) {
+  debug('registering callback getAdditionalParams');
+  this.addCallback('getAdditionalParams', fn);
+  return this;
+};
+backward(app, 'additionalParams', 'getAdditionalParams');
 
 /**
  * Register a callback to render the 'login' page
@@ -602,3 +625,16 @@ app.exchange = function(type, fn) {
   this._server.exchange(type, fn);
   return this;
 };
+
+/**
+ * Backward compatible helper
+ *
+ * @api private
+ */
+
+function backward(app, old, current) {
+  app[old] = function(fn) {
+    console.warn('***WARNING***', old, 'has been deprecated in favor of', current);
+    return this[current](fn);
+  };
+}

--- a/lib/auth/client.js
+++ b/lib/auth/client.js
@@ -22,7 +22,7 @@ var AuthorizationError = require('oauth2orize/lib/errors/authorizationerror');
  */
 
 exports = module.exports = function(callbacks) {
-  var getClient = callbacks('client');
+  var getClient = callbacks('getClient');
 
   function verifyClientCredentials(req, clientID, clientSecret, done) {
     debug('getting client', clientID);

--- a/lib/auth/exchanges/client.js
+++ b/lib/auth/exchanges/client.js
@@ -8,7 +8,7 @@ var merge = require('../../utils').merge;
 
 module.exports = function(callbacks) {
   var issueToken = callbacks('issueToken');
-  var getAdditionalParams = callbacks('additionalParams', function(req, type, client, user, scope, done) { done(); });
+  var getAdditionalParams = callbacks('getAdditionalParams', function(req, type, client, user, scope, done) { done(); });
 
   return oauth2orize.exchange.clientCredentials(function(req, client, scope, done) {
     debug('issuing token for client', client);

--- a/lib/auth/exchanges/code.js
+++ b/lib/auth/exchanges/code.js
@@ -7,17 +7,17 @@ var oauth2orize = require('oauth2orize');
 var merge = require('../../utils').merge;
 
 module.exports = function(callbacks) {
-  var authorizationCode = callbacks('authorizationCode');
-  var getUser = callbacks('user');
+  var getAuthorizationCode = callbacks('getAuthorizationCode');
+  var getUser = callbacks('getUser');
   var issueToken = callbacks('issueToken');
   var invalidateAuthorizationCode = callbacks('invalidateAuthorizationCode');
   var createRefreshToken = callbacks('createRefreshToken', function(req, client, user, scope, done) { done(); });
-  var getAdditionalParams = callbacks('additionalParams', function(req, type, client, user, scope, done) { done(); });
+  var getAdditionalParams = callbacks('getAdditionalParams', function(req, type, client, user, scope, done) { done(); });
 
   return oauth2orize.exchange.code(function(req, client, code, redirectURI, done) {
     // Get auth code info from the code
     debug('getting authorization code', code);
-    authorizationCode(req, code, function(err, authCode) {
+    getAuthorizationCode(req, code, function(err, authCode) {
       debug('got authorization code', code, authCode);
       if (err) return done(err);
       if (!authCode) return done(null, false);

--- a/lib/auth/exchanges/password.js
+++ b/lib/auth/exchanges/password.js
@@ -7,18 +7,18 @@ var oauth2orize = require('oauth2orize');
 var merge = require('../../utils').merge;
 
 module.exports = function(callbacks) {
-  var userByUsername = callbacks('userByUsername');
+  var getUserByUsername = callbacks('getUserByUsername');
   var verifyPassword = callbacks('verifyPassword');
   var issueToken = callbacks('issueToken');
   var createRefreshToken = callbacks('createRefreshToken', function(req, client, user, scope, done) { done(); });
-  var getAdditionalParams = callbacks('additionalParams', function(req, type, client, user, scope, done) { done(); });
+  var getAdditionalParams = callbacks('getAdditionalParams', function(req, type, client, user, scope, done) { done(); });
 
   return oauth2orize.exchange.password(function(req, client, username, password, scope, done) {
     // TODO verify that this client is allowed to use the password exchange
 
     // Get the user from the username
     debug('getting user by username', username);
-    userByUsername(req, username, function(err, user) {
+    getUserByUsername(req, username, function(err, user) {
       debug('got user by username', username, user);
       if (err) return done(err);
       if (!user) return done(null, false);

--- a/lib/auth/exchanges/refresh_token.js
+++ b/lib/auth/exchanges/refresh_token.js
@@ -7,12 +7,12 @@ var oauth2orize = require('oauth2orize');
 var merge = require('../../utils').merge;
 
 module.exports = function(callbacks) {
-  var getRefreshToken = callbacks('refreshToken');
-  var getUser = callbacks('user');
+  var getRefreshToken = callbacks('getRefreshToken');
+  var getUser = callbacks('getUser');
   var issueToken = callbacks('issueToken');
   var createRefreshToken = callbacks('createRefreshToken');
   var invalidateRefreshToken = callbacks('invalidateRefreshToken');
-  var getAdditionalParams = callbacks('additionalParams', function(req, type, client, user, scope, done) { done(); });
+  var getAdditionalParams = callbacks('getAdditionalParams', function(req, type, client, user, scope, done) { done(); });
 
   return oauth2orize.exchange.refreshToken(function(req, client, refreshToken, scope, done) {
     // Get the refresh token information

--- a/lib/auth/server.js
+++ b/lib/auth/server.js
@@ -7,9 +7,9 @@ var oauth2orize = require('oauth2orize');
 
 exports = module.exports = function(callbacks) {
   var server = oauth2orize();
-  var getClient = callbacks('client');
-  var isValidClientRedirectURI = callbacks('isValidClientRedirectURI');
-  var getUserDecision = callbacks('userDecision', function(user, client, done) { done(); });
+  var getClient = callbacks('getClient');
+  var verifyClientRedirectURI = callbacks('verifyClientRedirectURI');
+  var getUserDecision = callbacks('getUserDecision', function(user, client, done) { done(); });
   var saveUserDecision = callbacks('saveUserDecision', function(user, client, decision, done) { done(); });
 
   // Serialize the client
@@ -37,7 +37,7 @@ exports = module.exports = function(callbacks) {
         if (err) return done(err);
         if (!client) return done(null, false);
 
-        isValidClientRedirectURI(req, client, redirectURI, function(err, isValid) {
+        verifyClientRedirectURI(req, client, redirectURI, function(err, isValid) {
           if (err) return done(err);
           if (!isValid) return done(null, isValid);
           return done(null, client, redirectURI)

--- a/lib/auth/user.js
+++ b/lib/auth/user.js
@@ -15,8 +15,8 @@ var LocalStrategy = require('passport-local').Strategy;
  */
 
 module.exports = function(callbacks) {
-  var getUser = callbacks('user');
-  var userByUsername = callbacks('userByUsername');
+  var getUser = callbacks('getUser');
+  var getUserByUsername = callbacks('getUserByUsername');
   var verifyPassword = callbacks('verifyPassword');
 
   passport.serializeUser(function(req, user, done) {
@@ -36,7 +36,7 @@ module.exports = function(callbacks) {
   passport.use(new LocalStrategy({passReqToCallback: true}, function(req, username, password, done) {
     // Get the user from the username
     debug('getting user by username', username);
-    userByUsername(req, username, function(err, user) {
+    getUserByUsername(req, username, function(err, user) {
       debug('got user by username', username, user);
       if (err) return done(err);
       if (!user) return done(null, false);

--- a/test/exchange.code.test.js
+++ b/test/exchange.code.test.js
@@ -10,13 +10,13 @@ describe('a code exchange', function() {
   var invalidatedCodes;
 
   var callbacks = {
-    'authorizationCode': function(req, code, done) {
+    'getAuthorizationCode': function(req, code, done) {
       var fullCode = {client_id: 'validClientId', user_id: 'validUserId', redirect_uri: 'validRedirectUri'};
       if (~invalidatedCodes.indexOf(code)) return done(null, false);
       if (code === 'validCode') return done(null, fullCode);
       done(null, null);
     },
-    'user': function(req, userId, done) {
+    'getUser': function(req, userId, done) {
       if (userId === 'validUserId') return done(null, {});
       done(null, null);
     },
@@ -30,7 +30,7 @@ describe('a code exchange', function() {
     'createRefreshToken': function(req, client, user, scope, done) {
       done(null);
     },
-    'additionalParams': function(req, type, client, user, scope, done) {
+    'getAdditionalParams': function(req, type, client, user, scope, done) {
       done(null);
     }
   }

--- a/test/fixtures/integration/index.js
+++ b/test/fixtures/integration/index.js
@@ -15,26 +15,26 @@ var app = module.exports = consulate({session: {
  */
 
 app
-  .user(db.getUser)
-  .userByUsername(db.getUserByUsername)
-  .client(db.getClient)
-  .authorizationCode(db.getAuthorizationCode)
+  .getUser(db.getUser)
+  .getUserByUsername(db.getUserByUsername)
+  .getClient(db.getClient)
+  .getAuthorizationCode(db.getAuthorizationCode)
   .createAuthorizationCode(db.createAuthorizationCode)
   .invalidateAuthorizationCode(db.invalidateAuthorizationCode)
-  .isValidClientRedirectURI(db.isValidClientRedirectURI);
+  .verifyClientRedirectURI(db.isValidClientRedirectURI);
 
 /**
  * Misc callbacks
  */
 
 app
-  .scopes(function(done) {
+  .getScopes(function(done) {
     done(null, []);
   })
-  .allowedUserScopes(function(user, done) {
+  .getAllowedUserScopes(function(user, done) {
     done(null, user.scopes);
   })
-  .userDecision(function(user, client, done) {
+  .getUserDecision(function(user, client, done) {
     done(null, null);
   })
   .saveUserDecision(function(user, client, decision, done) {
@@ -50,7 +50,7 @@ app
       scope: scope
     }));
   })
-  .refreshToken(function(refreshToken, done) {
+  .getRefreshToken(function(refreshToken, done) {
     done(null, {
       client_id: 'validClient',
       user_id: 'user1'

--- a/test/password.test.js
+++ b/test/password.test.js
@@ -7,7 +7,7 @@ var pass = require('..').exchanges.password
 
 describe('a password exchange', function() {
   var callbacks = {
-    'userByUsername': function(req, username, done) {
+    'getUserByUsername': function(req, username, done) {
       if (username === 'validuser') return done(null, {});
       done(null, null);
     },
@@ -21,7 +21,7 @@ describe('a password exchange', function() {
     'createRefreshToken': function(req, client, user, scope, done) {
       done(null);
     },
-    'additionalParams': function(req, type, client, user, scope, done) {
+    'getAdditionalParams': function(req, type, client, user, scope, done) {
       done(null);
     }
   }

--- a/test/refresh_token.test.js
+++ b/test/refresh_token.test.js
@@ -12,11 +12,11 @@ describe('a password exchange', function() {
     'issueToken': function(req, client, user, scope, done) {
       done(null, 'some-websafe-token-string');
     },
-    'user': function(req, userId, done) {
+    'getUser': function(req, userId, done) {
       if (userId === 'user123') return done(null, {});
       done(null, null);
     },
-    'refreshToken': function(req, refreshToken, done) {
+    'getRefreshToken': function(req, refreshToken, done) {
       if (refreshToken === 'badtoken') return done(null, false);
       done(null, {
         client_id: 'validclient',
@@ -26,7 +26,7 @@ describe('a password exchange', function() {
     'createRefreshToken': function(req, client, user, scope, done) {
       done(null);
     },
-    'additionalParams': function(req, type, client, user, scope, done) {
+    'getAdditionalParams': function(req, type, client, user, scope, done) {
       done(null);
     },
     'invalidateRefreshToken': function(req, refreshToken, done) {


### PR DESCRIPTION
The inconsistency of the callbacks has been bugging me. For getters we
have a noun and other callbacks we have verbs. It makes more sense to have
everything a verb.

I added some aliases for backwards compatibility as well.
